### PR TITLE
Update immunoStates.R

### DIFF
--- a/R/immunoStates.R
+++ b/R/immunoStates.R
@@ -33,7 +33,7 @@ immunoStatesDecov <- function(metaObject){
       stop("Unknown OS")
     }
   }
-  if(!get_os %in% c("mac","unix")){numCores = 1}
+  if(!get_os() %in% c("mac","unix")){numCores = 1}
   
   #compute expression matrices
   iSExpMat <- mclapply(metaObject$originalData,


### PR DESCRIPTION
Since `()` are missing after the `get_os` function name in the immunoStates.R file, whenever one downloads the MetaIntegrator package from CRAN, they cannot fully use it because of the error raised by the missing `()`